### PR TITLE
Improve portability of open system call

### DIFF
--- a/clog.h
+++ b/clog.h
@@ -279,8 +279,22 @@ const char *const CLOG_LEVEL_NAMES[] = {
 int
 clog_init_path(int id, const char *const path)
 {
-    int fd = open(path, O_CREAT | O_WRONLY | O_APPEND,
-                  S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    mode_t mode = 0;
+
+#if defined(S_IRUSR)
+    mode |= S_IRUSR;
+#endif
+#if defined(S_IWUSR)
+    mode |= S_IWUSR;
+#endif
+#if defined(S_IRGRP)
+    mode |= S_IRGRP;
+#endif
+#if defined(S_IROTH)
+    mode |= S_IROTH;
+#endif
+
+    int fd = open(path, O_CREAT | O_WRONLY | O_APPEND, mode);
     if (fd == -1) {
         _clog_err("Unable to open %s: %s\n", path, strerror(errno));
         return 1;


### PR DESCRIPTION
The mode parameter of the open system call isn't very portable.

Before using the mode parameter symbolic constants, clog now
checks to see if they are defined. If they are defined they are used,
otherwise they are not.

This adds support for GCC on the mingw platform.
