### PR TITLE
Make use of variadic macro for logging call.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -20,6 +20,6 @@ check: clog_test
 	@./clog_test
 
 clean:
-	rm -f clog_test clog_test.out *.o
+	rm -f clog_test *.out *.o
 
 .PHONY: clean check


### PR DESCRIPTION
The function clog_info (/_debug/..) is now replaced by
a variadic macro that "knows" the linenumber where it is.
This change is due, because the dependency on `va_copy`
already kind of enforces the use of C99 or later.

This very much simplifies the use of the logger:
Instead of typing
  clog_info(CLOG(my_logger_id), "Hello, %s!", "world");
if suffices to pass the logger id:
  clog_info(my_logger_id, "Hello, %s!", "world");

The replacement depends on the C/C++ version used
(variadic macros are part of the standard since C99/C++11).
The preprocessor checks for the version and defines the
macro if applicable.

This is backwards compatible, because if the macros are
defined, then CLOG(id) is defined as the identity function
doing nothing.